### PR TITLE
feat(llm-mock-server): 调整 stream 输出结构与 openai 保持一致

### DIFF
--- a/llm-mock-server/pkg/provider/chat/minimax.go
+++ b/llm-mock-server/pkg/provider/chat/minimax.go
@@ -7,9 +7,10 @@ import (
 	"net/http"
 	"time"
 
+	"llm-mock-server/pkg/utils"
+
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
-	"llm-mock-server/pkg/utils"
 )
 
 const (
@@ -18,8 +19,7 @@ const (
 	minimaxChatCompletionProPath = "/v1/text/chatcompletion_pro"
 )
 
-type minimaxProvider struct {
-}
+type minimaxProvider struct{}
 
 func (p *minimaxProvider) ShouldHandleRequest(ctx *gin.Context) bool {
 	context, _ := getRequestContext(ctx)

--- a/llm-mock-server/pkg/provider/chat/model.go
+++ b/llm-mock-server/pkg/provider/chat/model.go
@@ -69,14 +69,15 @@ type chatCompletionResponse struct {
 	Model             string                 `json:"model,omitempty"`
 	SystemFingerprint string                 `json:"system_fingerprint,omitempty"`
 	Object            string                 `json:"object,omitempty"`
-	Usage             usage                  `json:"usage,omitempty"`
+	Usage             *usage                 `json:"usage"`
 }
 
 type chatCompletionChoice struct {
-	Index        int          `json:"index"`
-	Message      *chatMessage `json:"message,omitempty"`
-	Delta        *chatMessage `json:"delta,omitempty"`
-	FinishReason string       `json:"finish_reason,omitempty"`
+	Index        int                    `json:"index"`
+	Message      *chatMessage           `json:"message,omitempty"`
+	Delta        *chatMessage           `json:"delta,omitempty"`
+	FinishReason *string                `json:"finish_reason"`
+	Logprobs     map[string]interface{} `json:"logprobs"`
 }
 
 type usage struct {

--- a/llm-mock-server/pkg/provider/chat/openai.go
+++ b/llm-mock-server/pkg/provider/chat/openai.go
@@ -6,13 +6,13 @@ import (
 	"net/http"
 	"time"
 
+	"llm-mock-server/pkg/utils"
+
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
-	"llm-mock-server/pkg/utils"
 )
 
-type openAiProvider struct {
-}
+type openAiProvider struct{}
 
 func (p *openAiProvider) ShouldHandleRequest(ctx *gin.Context) bool {
 	return true
@@ -60,10 +60,11 @@ func (p *openAiProvider) handleStreamResponse(ctx *gin.Context, chatRequest chat
 	}
 	streamResponseChoice := chatCompletionChoice{Delta: &chatMessage{}}
 	go func() {
-		for i, s := range response {
+		responseRunes := []rune(response)
+		for i, s := range responseRunes {
 			streamResponseChoice.Delta.Content = string(s)
-			if i == len(response)-1 {
-				streamResponseChoice.FinishReason = stopReason
+			if i == len(responseRunes)-1 {
+				streamResponseChoice.FinishReason = ptr(stopReason)
 			}
 			streamResponse.Choices = []chatCompletionChoice{streamResponseChoice}
 			jsonStr, _ := json.Marshal(streamResponse)
@@ -105,9 +106,9 @@ func createChatCompletionResponse(model, response string) chatCompletionResponse
 					Role:    roleAssistant,
 					Content: response,
 				},
-				FinishReason: stopReason,
+				FinishReason: ptr(stopReason),
 			},
 		},
-		Usage: completionMockUsage,
+		Usage: &completionMockUsage,
 	}
 }

--- a/llm-mock-server/pkg/provider/chat/util.go
+++ b/llm-mock-server/pkg/provider/chat/util.go
@@ -3,3 +3,7 @@ package chat
 func prompt2Response(prompt string) string {
 	return prompt
 }
+
+func ptr[T any](v T) *T {
+	return &v
+}


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

openai 官方接口默认会输出 choices 中的 "finish_reason":null,"logprobs":null 字段，并且 usage 为空时返回 null

### Ⅱ. Describe how to verify it


### Ⅲ. Special notes for reviews

