### PR TITLE
feat: improve gemini fidelity and add moonshot handler for llm-mock-server

### DIFF
--- a/llm-mock-server/pkg/provider/chat/gemini.go
+++ b/llm-mock-server/pkg/provider/chat/gemini.go
@@ -26,7 +26,7 @@ func (p *geminiProvider) ShouldHandleRequest(ctx *gin.Context) bool {
 	}
 	path := context.Path
 
-	// Gemini使用 /v1beta/models/{model}:generateContent 或 :streamGenerateContent 格式
+	// Gemini uses the /v1beta/models/{model}:generateContent or :streamGenerateContent format
 	return context.Host == geminiDomain &&
 		strings.HasPrefix(path, geminiPath) &&
 		(strings.HasSuffix(path, ":generateContent") ||
@@ -34,41 +34,39 @@ func (p *geminiProvider) ShouldHandleRequest(ctx *gin.Context) bool {
 }
 
 func (p *geminiProvider) HandleChatCompletions(ctx *gin.Context) {
-	// 验证Authorization header
-	authHeader := ctx.GetHeader("x-goog-api-key")
-	if authHeader == "" {
-		p.sendErrorResponse(ctx, http.StatusUnauthorized, "Unauthorized: Please provide an API key")
+	apiKey := ctx.GetHeader("x-goog-api-key")
+	if apiKey == "" {
+		apiKey = ctx.Query("key")
+	}
+	if apiKey == "" {
+		p.sendErrorResponse(ctx, http.StatusForbidden, "Method doesn't allow unregistered callers (callers without established identity). Please use API Key or other form of API consumer identity to call this API.")
 		return
 	}
 
-	modelAndAction := strings.SplitN(ctx.Param("modelAndAction"), ":", 2)
-	if len(modelAndAction) < 2 {
+	model, action, ok := parseGeminiModelAndAction(ctx.Request.URL.Path)
+	if !ok {
 		p.sendErrorResponse(ctx, http.StatusBadRequest, "Invalid model and action")
 		return
 	}
-
-	model := modelAndAction[0]
-	action := modelAndAction[1]
 	log.Infof("gemini request model: %s, action: %s", model, action)
 
-	// 解析请求体
+	// Parse request body
 	var geminiRequest geminiGenerateContentRequest
 	if err := ctx.ShouldBindJSON(&geminiRequest); err != nil {
 		p.sendErrorResponse(ctx, http.StatusBadRequest, fmt.Sprintf("Invalid request: %v", err.Error()))
 		return
 	}
 
-	// 验证请求体
+	// Validate request body
 	if err := p.validateRequest(&geminiRequest); err != nil {
 		p.sendErrorResponse(ctx, http.StatusBadRequest, fmt.Sprintf("Validation error: %v", err.Error()))
 		return
 	}
 
-	// 检查是否为流式请求
-	path := ctx.Request.URL.Path
-	isStreaming := strings.HasSuffix(path, ":streamGenerateContent")
+	// Check whether this is a streaming request
+	isStreaming := action == "streamGenerateContent"
 
-	// 生成回复内容
+	// Generate the reply content
 	content := p.generateResponse(&geminiRequest)
 
 	if isStreaming {
@@ -76,6 +74,18 @@ func (p *geminiProvider) HandleChatCompletions(ctx *gin.Context) {
 	} else {
 		p.handleNonStreamResponse(ctx, &geminiRequest, content)
 	}
+}
+
+// parseGeminiModelAndAction extracts the model and action from a path of the form /v1beta/models/{model}:{action}
+func parseGeminiModelAndAction(path string) (string, string, bool) {
+	if !strings.HasPrefix(path, geminiPath) {
+		return "", "", false
+	}
+	parts := strings.SplitN(strings.TrimPrefix(path, geminiPath), ":", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
 }
 
 func (p *geminiProvider) validateRequest(req *geminiGenerateContentRequest) error {
@@ -98,32 +108,40 @@ func (p *geminiProvider) validateRequest(req *geminiGenerateContentRequest) erro
 }
 
 func (p *geminiProvider) generateResponse(req *geminiGenerateContentRequest) string {
-	// 生成mock回复内容
+	// Generate the mock reply content
 	content := "This is a mock response from Gemini provider. "
-	if len(req.Contents) > 0 && len(req.Contents[0].Parts) > 0 {
-		text := req.Contents[0].Parts[0].Text
-		if len(text) > 50 {
-			content += "You said: " + text[:50] + "..."
-		} else {
-			content += "You said: " + text
+	if len(req.Contents) > 0 {
+		lastContent := req.Contents[len(req.Contents)-1]
+		if len(lastContent.Parts) > 0 {
+			runes := []rune(lastContent.Parts[0].Text)
+			if len(runes) > 50 {
+				content += "You said: " + string(runes[:50]) + "..."
+			} else {
+				content += "You said: " + string(runes)
+			}
 		}
 	}
 	return content
 }
 
 func (p *geminiProvider) handleStreamResponse(ctx *gin.Context, req *geminiGenerateContentRequest, response string) {
-	// 设置流式响应头
+	// Set streaming response headers
 	ctx.Header("Content-Type", "text/event-stream")
 	ctx.Header("Cache-Control", "no-cache")
 	ctx.Header("Connection", "keep-alive")
 	ctx.Header("Access-Control-Allow-Origin", "*")
 
-	// 将回复内容分割成单词进行流式传输
+	// Split the reply into words and stream them
 	words := strings.Fields(response)
 	totalWords := len(words)
 
 	for i, word := range words {
-		// 创建流式响应块
+		select {
+		case <-ctx.Request.Context().Done():
+			return
+		default:
+		}
+
 		chunk := geminiGenerateContentResponse{
 			Candidates: []geminiCandidate{
 				{
@@ -131,39 +149,44 @@ func (p *geminiProvider) handleStreamResponse(ctx *gin.Context, req *geminiGener
 						Parts: []geminiPart{
 							{Text: word + " "},
 						},
+						Role: "model",
 					},
-					FinishReason: "STOP",
+					Index: 0,
 				},
+			},
+			UsageMetadata: &geminiUsageMetadata{
+				PromptTokenCount:     completionMockUsage.PromptTokens,
+				CandidatesTokenCount: completionMockUsage.CompletionTokens,
+				TotalTokenCount:      completionMockUsage.TotalTokens,
 			},
 		}
 
-		// 最后一个块设置结束原因
+		// The final chunk carries the finish reason
 		if i == totalWords-1 {
 			chunk.Candidates[0].FinishReason = "STOP"
-		} else {
-			chunk.Candidates[0].FinishReason = ""
 		}
 
-		// 发送数据块 - 使用与OpenAI provider相同的方式
+		// Send the data chunk, in the same way as the OpenAI provider
 		data, err := json.Marshal(chunk)
 		if err != nil {
 			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to marshal response"})
 			return
 		}
 
-		// 使用streamEvent来渲染SSE数据
+		// Render SSE data via streamEvent and flush immediately so each event arrives on its own
 		ctx.Render(-1, streamEvent{Data: "data: " + string(data)})
+		ctx.Writer.Flush()
 
-		// 模拟流式传输延迟
-		time.Sleep(50 * time.Millisecond)
+		select {
+		case <-ctx.Request.Context().Done():
+			return
+		case <-time.After(50 * time.Millisecond):
+		}
 	}
-
-	// 发送结束标记 - 使用与OpenAI provider相同的方式
-	ctx.Render(-1, streamEvent{Data: "data: [DONE]"})
 }
 
 func (p *geminiProvider) handleNonStreamResponse(ctx *gin.Context, req *geminiGenerateContentRequest, response string) {
-	// 创建非流式响应
+	// Build the non-streaming response
 	geminiResponse := geminiGenerateContentResponse{
 		Candidates: []geminiCandidate{
 			{
@@ -171,12 +194,16 @@ func (p *geminiProvider) handleNonStreamResponse(ctx *gin.Context, req *geminiGe
 					Parts: []geminiPart{
 						{Text: response},
 					},
+					Role: "model",
 				},
 				FinishReason: "STOP",
+				Index:        0,
 			},
 		},
-		PromptFeedback: geminiPromptFeedback{
-			BlockReason: "BLOCK_REASON_UNSPECIFIED",
+		UsageMetadata: &geminiUsageMetadata{
+			PromptTokenCount:     completionMockUsage.PromptTokens,
+			CandidatesTokenCount: completionMockUsage.CompletionTokens,
+			TotalTokenCount:      completionMockUsage.TotalTokens,
 		},
 	}
 
@@ -188,24 +215,43 @@ func (p *geminiProvider) sendErrorResponse(ctx *gin.Context, statusCode int, mes
 		"error": gin.H{
 			"code":    statusCode,
 			"message": message,
+			"status":  geminiErrorStatus(statusCode),
 		},
 	})
 }
 
-// Gemini请求和响应的数据结构
+// geminiErrorStatus returns the google.rpc.Code name that the real Gemini API pairs with the given HTTP status code
+func geminiErrorStatus(statusCode int) string {
+	switch statusCode {
+	case http.StatusBadRequest:
+		return "INVALID_ARGUMENT"
+	case http.StatusUnauthorized:
+		return "UNAUTHENTICATED"
+	case http.StatusForbidden:
+		return "PERMISSION_DENIED"
+	case http.StatusNotFound:
+		return "NOT_FOUND"
+	case http.StatusTooManyRequests:
+		return "RESOURCE_EXHAUSTED"
+	default:
+		return "INTERNAL"
+	}
+}
+
+// Data structures of Gemini requests and responses
 type geminiGenerateContentRequest struct {
-	Contents         []geminiContent         `json:"contents" validate:"required,min=1"`
-	SafetySettings   []geminiSafetySetting   `json:"safety_settings,omitempty"`
-	GenerationConfig *geminiGenerationConfig `json:"generation_config,omitempty"`
+	Contents         []geminiContent         `json:"contents"`
+	SafetySettings   []geminiSafetySetting   `json:"safetySettings,omitempty"`
+	GenerationConfig *geminiGenerationConfig `json:"generationConfig,omitempty"`
 }
 
 type geminiContent struct {
-	Parts []geminiPart `json:"parts" validate:"required,min=1"`
+	Parts []geminiPart `json:"parts"`
 	Role  string       `json:"role,omitempty"`
 }
 
 type geminiPart struct {
-	Text string `json:"text" validate:"required"`
+	Text string `json:"text"`
 }
 
 type geminiSafetySetting struct {
@@ -215,21 +261,24 @@ type geminiSafetySetting struct {
 
 type geminiGenerationConfig struct {
 	Temperature     float64 `json:"temperature,omitempty"`
-	TopP            float64 `json:"top_p,omitempty"`
-	TopK            int     `json:"top_k,omitempty"`
-	MaxOutputTokens int     `json:"max_output_tokens,omitempty"`
+	TopP            float64 `json:"topP,omitempty"`
+	TopK            int     `json:"topK,omitempty"`
+	MaxOutputTokens int     `json:"maxOutputTokens,omitempty"`
 }
 
 type geminiGenerateContentResponse struct {
-	Candidates     []geminiCandidate    `json:"candidates"`
-	PromptFeedback geminiPromptFeedback `json:"prompt_feedback,omitempty"`
+	Candidates    []geminiCandidate    `json:"candidates"`
+	UsageMetadata *geminiUsageMetadata `json:"usageMetadata,omitempty"`
 }
 
 type geminiCandidate struct {
 	Content      geminiContent `json:"content"`
-	FinishReason string        `json:"finish_reason"`
+	FinishReason string        `json:"finishReason,omitempty"`
+	Index        int           `json:"index"`
 }
 
-type geminiPromptFeedback struct {
-	BlockReason string `json:"block_reason"`
+type geminiUsageMetadata struct {
+	PromptTokenCount     int `json:"promptTokenCount"`
+	CandidatesTokenCount int `json:"candidatesTokenCount"`
+	TotalTokenCount      int `json:"totalTokenCount"`
 }

--- a/llm-mock-server/pkg/provider/chat/model.go
+++ b/llm-mock-server/pkg/provider/chat/model.go
@@ -224,6 +224,7 @@ type chatCompletionChoice struct {
 	Delta        *chatMessage           `json:"delta,omitempty"`
 	FinishReason *string                `json:"finish_reason"`
 	Logprobs     map[string]interface{} `json:"logprobs"`
+	Usage        *usage                 `json:"usage,omitempty"`
 }
 
 type usage struct {

--- a/llm-mock-server/pkg/provider/chat/moonshot.go
+++ b/llm-mock-server/pkg/provider/chat/moonshot.go
@@ -1,0 +1,127 @@
+package chat
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"llm-mock-server/pkg/log"
+	"llm-mock-server/pkg/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	moonshotDomain             = "api.moonshot.cn"
+	moonshotChatCompletionPath = "/v1/chat/completions"
+)
+
+// moonshot stream chunks carry no top-level usage; the final chunk nests it in choices[0].usage.
+type moonshotStreamResponse struct {
+	Id      string                 `json:"id,omitempty"`
+	Choices []chatCompletionChoice `json:"choices"`
+	Created int64                  `json:"created,omitempty"`
+	Model   string                 `json:"model,omitempty"`
+	Object  string                 `json:"object,omitempty"`
+}
+
+type moonshotProvider struct{}
+
+func (p *moonshotProvider) ShouldHandleRequest(ctx *gin.Context) bool {
+	context, err := getRequestContext(ctx)
+	if err != nil {
+		log.Errorf("get request context failed: %v", err)
+		return false
+	}
+	return context.Host == moonshotDomain && context.Path == moonshotChatCompletionPath
+}
+
+func (p *moonshotProvider) HandleChatCompletions(ctx *gin.Context) {
+	// The real moonshot API requires "Authorization: Bearer <api key>"; the error body mirrors the actual API response.
+	if !strings.HasPrefix(ctx.GetHeader("Authorization"), "Bearer ") {
+		ctx.JSON(http.StatusUnauthorized, gin.H{
+			"error": gin.H{
+				"message": "Incorrect API key provided",
+				"type":    "incorrect_api_key_error",
+			},
+		})
+		return
+	}
+
+	var chatRequest chatCompletionRequest
+	if !bindAndValidateChatRequest(ctx, &chatRequest) {
+		return
+	}
+	response := prompt2Response(lastStringPrompt(&chatRequest))
+
+	if chatRequest.Stream {
+		p.handleStreamResponse(ctx, chatRequest, response)
+	} else {
+		ctx.JSON(http.StatusOK, createChatCompletionResponse(chatRequest.Model, response))
+	}
+}
+
+func (p *moonshotProvider) handleStreamResponse(ctx *gin.Context, chatRequest chatCompletionRequest, response string) {
+	utils.SetEventStreamHeaders(ctx)
+	dataChan := make(chan string)
+	stopChan := make(chan bool, 1)
+	streamResponse := moonshotStreamResponse{
+		Id:      completionMockId,
+		Object:  objectChatCompletionChunk,
+		Created: completionMockCreated,
+		Model:   chatRequest.Model,
+	}
+	go func() {
+		sendChunk := func(choice chatCompletionChoice) bool {
+			streamResponse.Choices = []chatCompletionChoice{choice}
+			jsonStr, _ := json.Marshal(streamResponse)
+			select {
+			case dataChan <- string(jsonStr):
+				return true
+			case <-ctx.Request.Context().Done():
+				// client gone; stop producing to avoid leaking this goroutine
+				return false
+			}
+		}
+
+		// The first chunk carries the role and an empty content, matching the streaming example in the official docs.
+		if !sendChunk(chatCompletionChoice{Delta: &chatMessage{Role: roleAssistant, Content: ""}}) {
+			return
+		}
+
+		for _, s := range []rune(response) {
+			if !sendChunk(chatCompletionChoice{Delta: &chatMessage{Content: string(s)}}) {
+				return
+			}
+			// Simulate response delay; cancel promptly if the client disconnects
+			select {
+			case <-ctx.Request.Context().Done():
+				return
+			case <-time.After(50 * time.Millisecond):
+			}
+		}
+
+		// Moonshot-specific: the stream ends with an empty-delta block whose usage is nested in choices[0].usage (the end data block shape of the real API).
+		if !sendChunk(chatCompletionChoice{
+			Delta:        &chatMessage{},
+			FinishReason: ptr(stopReason),
+			Usage:        &completionMockUsage,
+		}) {
+			return
+		}
+		stopChan <- true
+	}()
+
+	ctx.Stream(func(w io.Writer) bool {
+		select {
+		case data := <-dataChan:
+			ctx.Render(-1, streamEvent{Data: "data: " + data})
+			return true
+		case <-stopChan:
+			ctx.Render(-1, streamEvent{Data: "data: [DONE]"})
+			return false
+		}
+	})
+}

--- a/llm-mock-server/pkg/provider/chat/openai.go
+++ b/llm-mock-server/pkg/provider/chat/openai.go
@@ -9,7 +9,6 @@ import (
 	"llm-mock-server/pkg/utils"
 
 	"github.com/gin-gonic/gin"
-	"github.com/go-playground/validator/v10"
 )
 
 type openAiProvider struct{}
@@ -19,27 +18,11 @@ func (p *openAiProvider) ShouldHandleRequest(ctx *gin.Context) bool {
 }
 
 func (p *openAiProvider) HandleChatCompletions(ctx *gin.Context) {
-	// Bind request body
 	var chatRequest chatCompletionRequest
-	if err := ctx.ShouldBindJSON(&chatRequest); err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	if !bindAndValidateChatRequest(ctx, &chatRequest) {
 		return
 	}
-
-	// Validate request body
-	if err := utils.Validate.Struct(chatRequest); err != nil {
-		validationErrors := err.(validator.ValidationErrors)
-		for _, fieldError := range validationErrors {
-			ctx.JSON(http.StatusBadRequest, gin.H{"error": fieldError.Error()})
-			return
-		}
-	}
-
-	prompt := ""
-	if chatRequest.Messages[len(chatRequest.Messages)-1].IsStringContent() {
-		prompt = chatRequest.Messages[len(chatRequest.Messages)-1].StringContent()
-	}
-	response := prompt2Response(prompt)
+	response := prompt2Response(lastStringPrompt(&chatRequest))
 
 	if chatRequest.Stream {
 		p.handleStreamResponse(ctx, chatRequest, response)
@@ -58,17 +41,21 @@ func (p *openAiProvider) handleStreamResponse(ctx *gin.Context, chatRequest chat
 		Created: completionMockCreated,
 		Model:   chatRequest.Model,
 	}
-	streamResponseChoice := chatCompletionChoice{Delta: &chatMessage{}}
 	go func() {
 		responseRunes := []rune(response)
 		for i, s := range responseRunes {
-			streamResponseChoice.Delta.Content = string(s)
+			choice := chatCompletionChoice{Delta: &chatMessage{Content: string(s)}}
 			if i == len(responseRunes)-1 {
-				streamResponseChoice.FinishReason = ptr(stopReason)
+				choice.FinishReason = ptr(stopReason)
 			}
-			streamResponse.Choices = []chatCompletionChoice{streamResponseChoice}
+			streamResponse.Choices = []chatCompletionChoice{choice}
 			jsonStr, _ := json.Marshal(streamResponse)
-			dataChan <- string(jsonStr)
+			select {
+			case dataChan <- string(jsonStr):
+			case <-ctx.Request.Context().Done():
+				// client gone; stop producing to avoid leaking this goroutine
+				return
+			}
 
 			// Simulate response delay
 			time.Sleep(200 * time.Millisecond)

--- a/llm-mock-server/pkg/provider/chat/provider.go
+++ b/llm-mock-server/pkg/provider/chat/provider.go
@@ -20,13 +20,25 @@ type requestHandler interface {
 }
 
 var (
-	chatCompletionsHandlers = map[string]requestHandler{
-		"minimax": &minimaxProvider{},
-		"dify":    &difyProvider{},
-		"qwen":    &qwenProvider{},
-		"gemini":  &geminiProvider{},
-		"openai":  &openAiProvider{}, // As the last fallback
+	orderedChatCompletionsHandlers = []struct {
+		name    string
+		handler requestHandler
+	}{
+		{"minimax", &minimaxProvider{}},
+		{"dify", &difyProvider{}},
+		{"qwen", &qwenProvider{}},
+		{"gemini", &geminiProvider{}},
+		{"moonshot", &moonshotProvider{}},
+		{"openai", &openAiProvider{}}, // As the last fallback
 	}
+
+	chatCompletionsHandlers = func() map[string]requestHandler {
+		handlers := make(map[string]requestHandler, len(orderedChatCompletionsHandlers))
+		for _, entry := range orderedChatCompletionsHandlers {
+			handlers[entry.name] = entry.handler
+		}
+		return handlers
+	}()
 
 	chatCompletionsRoutes = []string{
 		// baidu
@@ -52,9 +64,8 @@ var (
 		"/v1/chat-messages",
 		// gemini
 		"/v1beta/models/:modelAndAction",
-		// cloudflare 
-		"/client/v4/accounts/:accountId/ai/v1/chat/completions", 
-
+		// cloudflare
+		"/client/v4/accounts/:accountId/ai/v1/chat/completions",
 	}
 )
 
@@ -84,8 +95,10 @@ func SetupRoutes(server *gin.Engine, providerType string) {
 	case "groq":
 		server.POST("/openai/v1/chat/completions", chatCompletionsHandlers["openai"].HandleChatCompletions)
 	case "cloudflare":
-		server.POST("/client/v4/accounts/:accountId/ai/v1/chat/completions", chatCompletionsHandlers["cloudflare"].HandleChatCompletions)
+		server.POST("/client/v4/accounts/:accountId/ai/v1/chat/completions", chatCompletionsHandlers["openai"].HandleChatCompletions)
 	// 其他 cases...
+	case "moonshot":
+		server.POST("/v1/chat/completions", chatCompletionsHandlers["moonshot"].HandleChatCompletions)
 	case "openai", "ai360", "deepseek", "together", "baichuan", "yi", "stepfun":
 		// 这些provider都使用OpenAI兼容的格式，调用openAiProvider
 		server.POST("/v1/chat/completions", chatCompletionsHandlers["openai"].HandleChatCompletions)
@@ -106,9 +119,9 @@ func handleChatCompletions(context *gin.Context) {
 	if err := buildRequestContext(context); err != nil {
 		return
 	}
-	for _, handler := range chatCompletionsHandlers {
-		if handler.ShouldHandleRequest(context) {
-			handler.HandleChatCompletions(context)
+	for _, entry := range orderedChatCompletionsHandlers {
+		if entry.handler.ShouldHandleRequest(context) {
+			entry.handler.HandleChatCompletions(context)
 			return
 		}
 	}

--- a/llm-mock-server/pkg/provider/chat/util.go
+++ b/llm-mock-server/pkg/provider/chat/util.go
@@ -1,9 +1,38 @@
 package chat
 
+import (
+	"net/http"
+
+	"llm-mock-server/pkg/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
 func prompt2Response(prompt string) string {
 	return prompt
 }
 
 func ptr[T any](v T) *T {
 	return &v
+}
+
+// bindAndValidateChatRequest binds and validates the request body, writing a 400 response on failure.
+func bindAndValidateChatRequest(ctx *gin.Context, chatRequest *chatCompletionRequest) bool {
+	if err := ctx.ShouldBindJSON(chatRequest); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return false
+	}
+	if err := utils.Validate.Struct(chatRequest); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return false
+	}
+	return true
+}
+
+func lastStringPrompt(chatRequest *chatCompletionRequest) string {
+	last := chatRequest.Messages[len(chatRequest.Messages)-1]
+	if last.IsStringContent() {
+		return last.StringContent()
+	}
+	return ""
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Improve the gemini handler's fidelity to the real API and add a moonshot handler, unblocking the ai-proxy e2e cases of higress-group/higress#1717 and higress-group/higress#1722.

- **gemini**: camelCase fields, `usageMetadata` on every stream chunk, no `[DONE]` sentinel, header/`?key=` auth, 403 on missing key — verified against the official docs and live API probes.
- **moonshot**: new host-dispatched handler; the final stream block nests usage in `choices[0].usage` per the [official docs](https://platform.kimi.com/docs/api/chat); Bearer auth required.
- **dispatch**: single ordered handler slice (openai fallback last); fix the `--provider-type=cloudflare` nil-handler panic; stop stream producers on client disconnect.

The mock stays text-only; full request schemas and API-key validation are out of scope.

### Ⅱ. Describe how to verify it

```bash
cd llm-mock-server && go build ./... && go test ./...
```

With this image, the full higress `WasmPluginAiProxy` e2e suite (including the new moonshot/gemini cases) passes on a local kind cluster.

### Ⅲ. Special notes for reviews

- higress-group/higress#4069 and higress-group/higress#4075 depend on this PR and the `llm-mock-server:latest` image rebuild; both stay in draft until then.
- Removing gemini's `[DONE]` is intentional: the real Gemini stream ends without a sentinel.
