### PR TITLE
feat: add claude, cohere, hunyuan, deepl provider mocks

### DIFF
--- a/llm-mock-server/pkg/provider/chat/claude.go
+++ b/llm-mock-server/pkg/provider/chat/claude.go
@@ -1,0 +1,241 @@
+package chat
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"llm-mock-server/pkg/log"
+	"llm-mock-server/pkg/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	claudeDomain       = "api.anthropic.com"
+	claudeMessagesPath = "/v1/messages"
+	// claudeMockId is an Anthropic-style message id. ai-proxy passes it through as the OpenAI response id.
+	claudeMockId    = "msg_llm-mock"
+	claudeMockModel = "claude-3-5-sonnet-20241022"
+	// claudeMockRequestId mirrors the request id the real API returns in every error body and the
+	// "request-id" response header.
+	claudeMockRequestId = "req_llm-mock"
+)
+
+// claudeError writes an Anthropic-style error response: the request-id header plus a body carrying
+// the top-level type/request_id and the nested error object, matching the real API's error shape.
+func claudeError(ctx *gin.Context, status int, errType, message string) {
+	ctx.Header("request-id", claudeMockRequestId)
+	ctx.JSON(status, gin.H{
+		"type":       "error",
+		"request_id": claudeMockRequestId,
+		"error":      gin.H{"type": errType, "message": message},
+	})
+}
+
+// claudeMessagesRequest is the Anthropic /v1/messages request shape. ai-proxy sends this
+// after converting the client's OpenAI-format request.
+type claudeMessagesRequest struct {
+	Model    string          `json:"model"`
+	Messages []claudeMessage `json:"messages"`
+	System   json.RawMessage `json:"system,omitempty"`
+	Stream   bool            `json:"stream,omitempty"`
+	Tools    []claudeTool    `json:"tools,omitempty"`
+}
+
+type claudeTool struct {
+	Name string `json:"name"`
+}
+
+type claudeMessage struct {
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"` // string or [{type,text,...}]
+}
+
+type claudeProvider struct{}
+
+func (p *claudeProvider) ShouldHandleRequest(ctx *gin.Context) bool {
+	context, err := getRequestContext(ctx)
+	if err != nil {
+		log.Errorf("get request context failed: %v", err)
+		return false
+	}
+	return context.Host == claudeDomain && context.Path == claudeMessagesPath
+}
+
+func (p *claudeProvider) HandleChatCompletions(ctx *gin.Context) {
+	// The real API requires the anthropic-version header (ai-proxy always injects it).
+	if ctx.GetHeader("anthropic-version") == "" {
+		claudeError(ctx, http.StatusBadRequest, "invalid_request_error", "anthropic-version header is required")
+		return
+	}
+	// The real Anthropic API authenticates with the "x-api-key" header; the error body mirrors it.
+	if ctx.GetHeader("x-api-key") == "" {
+		claudeError(ctx, http.StatusUnauthorized, "authentication_error", "invalid x-api-key")
+		return
+	}
+
+	var req claudeMessagesRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	response := lastClaudeUserText(&req)
+
+	// A sentinel prompt makes the mock return the upstream auth error, letting the e2e verify that
+	// ai-proxy surfaces an upstream 401 to the client instead of masking it.
+	if response == "__force_auth_error__" {
+		claudeError(ctx, http.StatusUnauthorized, "authentication_error", "invalid x-api-key")
+		return
+	}
+
+	// When the request carries tools, reply with a tool_use block so the tool-call conversion path
+	// is exercised (the mock always calls the first tool with a fixed argument).
+	if len(req.Tools) > 0 && req.Stream {
+		p.handleToolUseStreamResponse(ctx, req.Tools[0].Name)
+		return
+	}
+
+	if req.Stream {
+		p.handleStreamResponse(ctx, response)
+	} else {
+		p.handleNonStreamResponse(ctx, response)
+	}
+}
+
+// handleToolUseStreamResponse emits an Anthropic tool_use streaming sequence: message_start,
+// content_block_start (tool_use), input_json_delta chunks, content_block_stop, message_delta
+// (stop_reason tool_use), message_stop.
+func (p *claudeProvider) handleToolUseStreamResponse(ctx *gin.Context, toolName string) {
+	utils.SetEventStreamHeaders(ctx)
+	send := func(payload gin.H) bool {
+		data, _ := json.Marshal(payload)
+		select {
+		case <-ctx.Request.Context().Done():
+			return false
+		default:
+		}
+		// Real Anthropic streaming uses named SSE events (event: <type> + data: <json>) since the
+		// 2023-06-01 version; ai-proxy reads only the data: lines but the mock stays wire-faithful.
+		// Write raw (not via streamEvent, whose data replacer would mangle the embedded newline).
+		eventType, _ := payload["type"].(string)
+		ctx.Writer.Write([]byte("event: " + eventType + "\ndata: " + string(data) + "\n\n"))
+		ctx.Writer.Flush()
+		return true
+	}
+
+	if !send(gin.H{"type": "message_start", "message": gin.H{
+		"id": claudeMockId, "type": "message", "role": roleAssistant, "model": claudeMockModel,
+		"content": []gin.H{}, "stop_reason": nil, "stop_sequence": nil,
+		"usage": gin.H{"input_tokens": completionMockUsage.PromptTokens, "output_tokens": 1},
+	}}) {
+		return
+	}
+	if !send(gin.H{"type": "content_block_start", "index": 0, "content_block": gin.H{
+		"type": "tool_use", "id": "toolu_llm-mock", "name": toolName, "input": gin.H{},
+	}}) {
+		return
+	}
+	// The tool arguments arrive as partial_json fragments that ai-proxy concatenates.
+	for _, frag := range []string{`{"location": `, `"Beijing"}`} {
+		if !send(gin.H{"type": "content_block_delta", "index": 0, "delta": gin.H{"type": "input_json_delta", "partial_json": frag}}) {
+			return
+		}
+	}
+	send(gin.H{"type": "content_block_stop", "index": 0})
+	send(gin.H{"type": "message_delta", "delta": gin.H{"stop_reason": "tool_use", "stop_sequence": nil}, "usage": gin.H{"output_tokens": completionMockUsage.CompletionTokens}})
+	send(gin.H{"type": "message_stop"})
+}
+
+func (p *claudeProvider) handleNonStreamResponse(ctx *gin.Context, response string) {
+	ctx.JSON(http.StatusOK, gin.H{
+		"id":            claudeMockId,
+		"type":          "message",
+		"role":          roleAssistant,
+		"model":         claudeMockModel,
+		"content":       []gin.H{{"type": "text", "text": response}},
+		"stop_reason":   "end_turn",
+		"stop_sequence": nil,
+		"usage": gin.H{
+			"input_tokens":  completionMockUsage.PromptTokens,
+			"output_tokens": completionMockUsage.CompletionTokens,
+		},
+	})
+}
+
+func (p *claudeProvider) handleStreamResponse(ctx *gin.Context, response string) {
+	utils.SetEventStreamHeaders(ctx)
+
+	send := func(payload gin.H) bool {
+		data, _ := json.Marshal(payload)
+		select {
+		case <-ctx.Request.Context().Done():
+			return false
+		default:
+		}
+		// Real Anthropic streaming uses named SSE events (event: <type> + data: <json>) since the
+		// 2023-06-01 version; ai-proxy reads only the data: lines but the mock stays wire-faithful.
+		// Write raw (not via streamEvent, whose data replacer would mangle the embedded newline).
+		eventType, _ := payload["type"].(string)
+		ctx.Writer.Write([]byte("event: " + eventType + "\ndata: " + string(data) + "\n\n"))
+		ctx.Writer.Flush()
+		return true
+	}
+
+	// message_start carries the assistant role and the input usage plus a small initial
+	// output_tokens (the real API reports ~1 here; the cumulative total arrives in message_delta).
+	if !send(gin.H{"type": "message_start", "message": gin.H{
+		"id": claudeMockId, "type": "message", "role": roleAssistant, "model": claudeMockModel,
+		"content": []gin.H{}, "stop_reason": nil, "stop_sequence": nil,
+		"usage": gin.H{"input_tokens": completionMockUsage.PromptTokens, "output_tokens": 1},
+	}}) {
+		return
+	}
+	if !send(gin.H{"type": "content_block_start", "index": 0, "content_block": gin.H{"type": "text", "text": ""}}) {
+		return
+	}
+
+	// One text_delta per rune, mirroring the byte-by-byte streaming of the other provider mocks.
+	for _, r := range response {
+		if !send(gin.H{"type": "content_block_delta", "index": 0, "delta": gin.H{"type": "text_delta", "text": string(r)}}) {
+			return
+		}
+		select {
+		case <-ctx.Request.Context().Done():
+			return
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+
+	send(gin.H{"type": "content_block_stop", "index": 0})
+	// message_delta.usage.output_tokens is the cumulative total for the whole message, matching the real Anthropic API.
+	send(gin.H{"type": "message_delta", "delta": gin.H{"stop_reason": "end_turn", "stop_sequence": nil}, "usage": gin.H{"output_tokens": completionMockUsage.CompletionTokens}})
+	send(gin.H{"type": "message_stop"})
+}
+
+// lastClaudeUserText returns the text of the last message, handling both string and
+// content-block-array content forms.
+func lastClaudeUserText(req *claudeMessagesRequest) string {
+	if len(req.Messages) == 0 {
+		return ""
+	}
+	last := req.Messages[len(req.Messages)-1]
+	var s string
+	if err := json.Unmarshal(last.Content, &s); err == nil {
+		return s
+	}
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(last.Content, &blocks); err == nil {
+		text := ""
+		for _, b := range blocks {
+			if b.Type == "text" {
+				text += b.Text
+			}
+		}
+		return text
+	}
+	return ""
+}

--- a/llm-mock-server/pkg/provider/chat/cohere.go
+++ b/llm-mock-server/pkg/provider/chat/cohere.go
@@ -1,0 +1,128 @@
+package chat
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"llm-mock-server/pkg/log"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	cohereDomain   = "api.cohere.com"
+	cohereChatPath = "/v1/chat"
+)
+
+// cohereRequest is the Cohere v1 /v1/chat request shape. ai-proxy sends this after converting
+// the client's OpenAI-format request (it maps the first message to the top-level "message").
+type cohereRequest struct {
+	Message string `json:"message"`
+	Stream  bool   `json:"stream"`
+}
+
+type cohereProvider struct{}
+
+func (p *cohereProvider) ShouldHandleRequest(ctx *gin.Context) bool {
+	context, err := getRequestContext(ctx)
+	if err != nil {
+		log.Errorf("get request context failed: %v", err)
+		return false
+	}
+	return context.Host == cohereDomain && context.Path == cohereChatPath
+}
+
+func (p *cohereProvider) HandleChatCompletions(ctx *gin.Context) {
+	// The real Cohere API requires "Authorization: Bearer <api key>"; ai-proxy always injects it.
+	if ctx.GetHeader("Authorization") == "" {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"message": "invalid api token"})
+		return
+	}
+
+	var req cohereRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
+		return
+	}
+
+	// This native Cohere response is what ai-proxy converts to OpenAI shape.
+	if req.Stream {
+		p.handleStreamResponse(ctx, req.Message)
+	} else {
+		p.handleNonStreamResponse(ctx, req.Message)
+	}
+}
+
+// cohereMeta builds the Cohere v1 "meta" object, which carries api_version plus tokens and billed_units.
+func cohereMeta() gin.H {
+	counts := gin.H{
+		"input_tokens":  completionMockUsage.PromptTokens,
+		"output_tokens": completionMockUsage.CompletionTokens,
+	}
+	return gin.H{
+		"api_version":  gin.H{"version": "1"},
+		"tokens":       counts,
+		"billed_units": counts,
+	}
+}
+
+func (p *cohereProvider) handleNonStreamResponse(ctx *gin.Context, response string) {
+	ctx.JSON(http.StatusOK, gin.H{
+		"response_id":   completionMockId,
+		"text":          response,
+		"generation_id": completionMockId,
+		"chat_history": []gin.H{
+			{"role": "USER", "message": response},
+			{"role": "CHATBOT", "message": response},
+		},
+		"finish_reason": "COMPLETE",
+		"meta":          cohereMeta(),
+	})
+}
+
+func (p *cohereProvider) handleStreamResponse(ctx *gin.Context, response string) {
+	// ai-proxy requests streaming with Accept: text/event-stream, so Cohere replies with SSE frames
+	// (event: <event_type> + data: <json>).
+	ctx.Header("Content-Type", "text/event-stream")
+	ctx.Status(http.StatusOK)
+
+	send := func(payload gin.H) bool {
+		data, _ := json.Marshal(payload)
+		select {
+		case <-ctx.Request.Context().Done():
+			return false
+		default:
+		}
+		eventType, _ := payload["event_type"].(string)
+		ctx.Writer.Write([]byte("event: " + eventType + "\ndata: " + string(data) + "\n\n"))
+		ctx.Writer.Flush()
+		return true
+	}
+
+	if !send(gin.H{"event_type": "stream-start", "generation_id": completionMockId, "is_finished": false}) {
+		return
+	}
+	for _, r := range response {
+		if !send(gin.H{"event_type": "text-generation", "text": string(r), "is_finished": false}) {
+			return
+		}
+		select {
+		case <-ctx.Request.Context().Done():
+			return
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	send(gin.H{
+		"event_type":    "stream-end",
+		"is_finished":   true,
+		"finish_reason": "COMPLETE",
+		"response": gin.H{
+			"response_id":   completionMockId,
+			"text":          response,
+			"generation_id": completionMockId,
+			"finish_reason": "COMPLETE",
+			"meta":          cohereMeta(),
+		},
+	})
+}

--- a/llm-mock-server/pkg/provider/chat/deepl.go
+++ b/llm-mock-server/pkg/provider/chat/deepl.go
@@ -1,0 +1,59 @@
+package chat
+
+import (
+	"net/http"
+
+	"llm-mock-server/pkg/log"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	deeplHostFree       = "api-free.deepl.com"
+	deeplHostPro        = "api.deepl.com"
+	deeplTranslatePath  = "/v2/translate"
+	deeplDetectedSource = "EN" // fixed detected source language the mock reports
+)
+
+// deeplRequest is the DeepL /v2/translate request shape. ai-proxy sends this (JSON) after
+// converting the client's OpenAI-format request; the messages become the "text" array and
+// target_lang comes from the provider's targetLang config.
+type deeplRequest struct {
+	Text       []string `json:"text"`
+	TargetLang string   `json:"target_lang"`
+	Context    string   `json:"context"`
+}
+
+type deeplProvider struct{}
+
+func (p *deeplProvider) ShouldHandleRequest(ctx *gin.Context) bool {
+	context, err := getRequestContext(ctx)
+	if err != nil {
+		log.Errorf("get request context failed: %v", err)
+		return false
+	}
+	return (context.Host == deeplHostFree || context.Host == deeplHostPro) && context.Path == deeplTranslatePath
+}
+
+func (p *deeplProvider) HandleChatCompletions(ctx *gin.Context) {
+	// The real DeepL API authenticates with "Authorization: DeepL-Auth-Key <key>"; ai-proxy injects it.
+	if ctx.GetHeader("Authorization") == "" {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"message": "invalid api token"})
+		return
+	}
+
+	var req deeplRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
+		return
+	}
+
+	// DeepL returns one translation per input text; echo each entry back.
+	translations := make([]gin.H, 0, len(req.Text))
+	for _, t := range req.Text {
+		translations = append(translations, gin.H{"detected_source_language": deeplDetectedSource, "text": t})
+	}
+
+	// DeepL translation is non-streaming; ai-proxy converts this to an OpenAI chat.completion.
+	ctx.JSON(http.StatusOK, gin.H{"translations": translations})
+}

--- a/llm-mock-server/pkg/provider/chat/hunyuan.go
+++ b/llm-mock-server/pkg/provider/chat/hunyuan.go
@@ -1,0 +1,154 @@
+package chat
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"llm-mock-server/pkg/log"
+	"llm-mock-server/pkg/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	hunyuanDomain = "hunyuan.tencentcloudapi.com"
+	hunyuanPath   = "/"
+	// hunyuanNote is the disclaimer the real Hunyuan API always returns.
+	hunyuanNote = "以上内容为AI生成，不代表开发者立场，请勿删除或修改本标记"
+)
+
+// hunyuanRequest is the native Tencent Hunyuan ChatCompletions request shape (capitalized keys).
+// ai-proxy sends this after converting the client's OpenAI-format request. Only the text-chat
+// subset is modeled; Tools / ToolChoice are not (ai-proxy's hunyuan request does not forward them).
+type hunyuanRequest struct {
+	Model    string `json:"Model"`
+	Messages []struct {
+		Role    string `json:"Role"`
+		Content string `json:"Content"`
+	} `json:"Messages"`
+	Stream bool `json:"Stream"`
+}
+
+type hunyuanProvider struct{}
+
+func (p *hunyuanProvider) ShouldHandleRequest(ctx *gin.Context) bool {
+	context, err := getRequestContext(ctx)
+	if err != nil {
+		log.Errorf("get request context failed: %v", err)
+		return false
+	}
+	return context.Host == hunyuanDomain && context.Path == hunyuanPath
+}
+
+func (p *hunyuanProvider) HandleChatCompletions(ctx *gin.Context) {
+	// The real API rejects unsigned requests; ai-proxy always sets a TC3 Authorization header.
+	if ctx.GetHeader("Authorization") == "" {
+		ctx.JSON(http.StatusUnauthorized, gin.H{
+			"Response": gin.H{"Error": gin.H{"Code": "AuthFailure", "Message": "missing Authorization"}},
+		})
+		return
+	}
+	// The native TC3 API is selected by the X-TC-Action / X-TC-Version headers; ai-proxy always
+	// injects them (X-TC-Action: ChatCompletions, X-TC-Version: 2023-09-01).
+	if ctx.GetHeader("X-TC-Action") != "ChatCompletions" || ctx.GetHeader("X-TC-Version") != "2023-09-01" {
+		ctx.JSON(http.StatusBadRequest, gin.H{
+			"Response": gin.H{"Error": gin.H{"Code": "InvalidAction", "Message": "invalid X-TC-Action / X-TC-Version"}},
+		})
+		return
+	}
+
+	var req hunyuanRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"Response": gin.H{"Error": gin.H{"Message": err.Error()}}})
+		return
+	}
+	response := lastHunyuanUserText(&req)
+
+	// The real API returns the request id in the X-TC-RequestId response header.
+	ctx.Header("X-TC-RequestId", completionMockId)
+	if req.Stream {
+		p.handleStreamResponse(ctx, response)
+	} else {
+		p.handleNonStreamResponse(ctx, response)
+	}
+}
+
+func (p *hunyuanProvider) handleNonStreamResponse(ctx *gin.Context, response string) {
+	ctx.JSON(http.StatusOK, gin.H{
+		"Response": gin.H{
+			"RequestId": completionMockId,
+			"Note":      hunyuanNote,
+			"Id":        completionMockId, // becomes the OpenAI response "id"
+			"Created":   completionMockCreated,
+			"Choices": []gin.H{{
+				"Index":        0,
+				"FinishReason": stopReason,
+				"Message":      gin.H{"Role": roleAssistant, "Content": response},
+			}},
+			"Usage": gin.H{
+				"PromptTokens":     completionMockUsage.PromptTokens,
+				"CompletionTokens": completionMockUsage.CompletionTokens,
+				"TotalTokens":      completionMockUsage.TotalTokens,
+			},
+		},
+	})
+}
+
+func (p *hunyuanProvider) handleStreamResponse(ctx *gin.Context, response string) {
+	utils.SetEventStreamHeaders(ctx)
+
+	// Every frame MUST carry a non-empty Choices array: ai-proxy indexes Choices[0]
+	// without a bounds check when converting Hunyuan chunks.
+	send := func(content, finish string) bool {
+		data, _ := json.Marshal(gin.H{
+			"Note":    hunyuanNote,
+			"Id":      completionMockId,
+			"Created": time.Now().Unix(),
+			"Choices": []gin.H{{
+				"Index":        0,
+				"Delta":        gin.H{"Role": roleAssistant, "Content": content},
+				"FinishReason": finish,
+			}},
+			"Usage": gin.H{
+				"PromptTokens":     completionMockUsage.PromptTokens,
+				"CompletionTokens": completionMockUsage.CompletionTokens,
+				"TotalTokens":      completionMockUsage.TotalTokens,
+			},
+		})
+		select {
+		case <-ctx.Request.Context().Done():
+			return false
+		default:
+		}
+		ctx.Render(-1, streamEvent{Data: "data: " + string(data)})
+		ctx.Writer.Flush()
+		return true
+	}
+
+	// One content delta per rune, then a terminal frame with finish_reason "stop" (native
+	// Hunyuan emits no [DONE]).
+	for _, r := range response {
+		if !send(string(r), "") {
+			return
+		}
+		select {
+		case <-ctx.Request.Context().Done():
+			return
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	send("", stopReason)
+}
+
+func lastHunyuanUserText(req *hunyuanRequest) string {
+	if len(req.Messages) == 0 {
+		return ""
+	}
+	for i := len(req.Messages) - 1; i >= 0; i-- {
+		if req.Messages[i].Role == "user" {
+			return req.Messages[i].Content
+		}
+	}
+	return req.Messages[len(req.Messages)-1].Content
+}

--- a/llm-mock-server/pkg/provider/chat/provider.go
+++ b/llm-mock-server/pkg/provider/chat/provider.go
@@ -30,6 +30,10 @@ var (
 		{"gemini", &geminiProvider{}},
 		{"vertex", &vertexProvider{}},
 		{"moonshot", &moonshotProvider{}},
+		{"claude", &claudeProvider{}},
+		{"cohere", &cohereProvider{}},
+		{"hunyuan", &hunyuanProvider{}},
+		{"deepl", &deeplProvider{}},
 		{"openai", &openAiProvider{}}, // As the last fallback
 	}
 
@@ -71,6 +75,14 @@ var (
 		"/v1/projects/:project/locations/:location/publishers/google/models/:modelAndAction",
 		// cloudflare
 		"/client/v4/accounts/:accountId/ai/v1/chat/completions",
+		// claude (anthropic)
+		"/v1/messages",
+		// cohere (v1 chat)
+		"/v1/chat",
+		// hunyuan (tencent native TC3 ChatCompletions)
+		"/",
+		// deepl (translate)
+		"/v2/translate",
 	}
 )
 


### PR DESCRIPTION
### What

Adds native-format mock handlers for four ai-proxy providers, so the Higress ai-proxy conformance e2e can run against a stable backing server:

- **claude**: Anthropic `/v1/messages` — named-event SSE streaming (text + tool_use), non-stream, `anthropic-version` validation, `request_id` in error bodies.
- **cohere**: Cohere v1 `/v1/chat` — non-stream + SSE streaming.
- **hunyuan**: Tencent native TC3 `ChatCompletions` (non-stream + SSE) with `X-TC-Action` / `X-TC-Version` validation and the `X-TC-RequestId` header.
- **deepl**: DeepL `/v2/translate`.

Each is registered in `orderedChatCompletionsHandlers` (before the openai fallback) and its route added to `chatCompletionsRoutes`.

### Related

Backs the ai-proxy e2e work under higress-group/higress#1629 (providers: higress-group/higress#1719, higress-group/higress#1738, higress-group/higress#1720, higress-group/higress#1723).

### Dependency / rollout

The downstream Higress ai-proxy e2e PR (claude/cohere/hunyuan/deepl) depends on this: it should merge **after** this PR is merged and the `llm-mock-server:latest` image is rebuilt, otherwise its CI would run against an image without these handlers.

That downstream PR is already passing locally against these handlers; it will be opened a bit later because it also needs a rebase against another in-flight ai-proxy e2e PR (both touch the same conformance test files).