### PR TITLE
fix: make the image build resilient to Go module proxy misses

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Build Docker image
         run: |
-          make image-buildx PROJECT=${{ github.event.inputs.project }} VERSION=${{ github.event.inputs.version }} REGISTRY=${{ env.IMAGE_REGISTRY }}
+          make image-buildx PROJECT=${{ github.event.inputs.project }} VERSION=${{ github.event.inputs.version }} REGISTRY=${{ env.IMAGE_REGISTRY }} BUILD=CI
 
       - name: Notify success
         run: echo "Docker image built and pushed successfully for project ${{ github.event.inputs.project }} and version ${{ github.event.inputs.version }}"

--- a/Makefile
+++ b/Makefile
@@ -23,4 +23,4 @@ image-buildx:  ## Build and push docker image for the specified project
 		echo "Error: PROJECT is not set"; \
 		exit 1; \
 	fi
-	docker buildx build --push --platform=$(PLATFORMS) --tag ${IMAGE} ./$(PROJECT)
+	docker buildx build --push --platform=$(PLATFORMS) --build-arg BUILD=$(BUILD) --tag ${IMAGE} ./$(PROJECT)

--- a/llm-mock-server/Dockerfile
+++ b/llm-mock-server/Dockerfile
@@ -1,5 +1,8 @@
 FROM golang:1.21.0-alpine3.17 AS builder
 
+# git is required when go mod download falls back to direct (VCS) mode
+RUN apk add --no-cache git
+
 # Build Args
 ARG BUILD
 WORKDIR /app


### PR DESCRIPTION
### Bug

The registry image build failed ([run 28767988141](https://github.com/higress-group/mock-server/actions/runs/28767988141)) at `go mod download`:

```
go: github.com/bytedance/sonic/loader@v0.2.1: git init --bare ...
exec: "git": executable file not found in $PATH
```

Two things combined:

1. The workflow never passes `BUILD=CI`, so the Dockerfile sets `GOPROXY=goproxy.io,direct` even in CI (that proxy is meant for local development).
2. When the proxy transiently misses a module, Go falls back to `direct` (VCS) mode, which needs `git` — not installed in the alpine builder image. So any proxy miss hard-fails the build.

### Fix

- **Dockerfile**: install `git` in the builder stage, so the `direct` fallback works whenever it happens.
- **Makefile / workflow**: wire `BUILD=CI` through to `docker buildx build`, so CI uses the default `proxy.golang.org` as originally intended. Local builds (no `BUILD`) keep using goproxy.io, unchanged.

### Verification (local)

- Reproduced the exact failure with `GOPROXY=direct` on the original image; passes with `git` installed.
- Ran the CI-equivalent `make image-buildx ... BUILD=CI` end-to-end for `linux/amd64 + linux/arm64`, including a real push to a local registry; confirmed `GOPROXY` stays `proxy.golang.org,direct` in CI mode, and the resulting image serves mock requests correctly.

Once merged, re-running the dispatch should rebuild `llm-mock-server:latest` (unblocking the e2e work that depends on the image, e.g. #14 handlers).